### PR TITLE
bug: [PagoPa-1847]: fixed cache transaction list

### DIFF
--- a/src/main/java/it/gov/pagopa/bizeventsservice/model/filterandorder/Order.java
+++ b/src/main/java/it/gov/pagopa/bizeventsservice/model/filterandorder/Order.java
@@ -1,0 +1,26 @@
+package it.gov.pagopa.bizeventsservice.model.filterandorder;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class Order {
+
+    @NotNull
+    private OrderType orderBy;
+
+    @Getter
+    @AllArgsConstructor
+    public enum TransactionListOrder implements OrderType {
+        TRANSACTION_DATE("transactionDate"),
+        TAX_CODE("taxCode");
+
+        private final String columnName;
+
+    }
+}

--- a/src/main/java/it/gov/pagopa/bizeventsservice/model/filterandorder/OrderType.java
+++ b/src/main/java/it/gov/pagopa/bizeventsservice/model/filterandorder/OrderType.java
@@ -1,0 +1,14 @@
+package it.gov.pagopa.bizeventsservice.model.filterandorder;
+
+/**
+ * This interface is implemented by the enumerations in the {@link Order} class
+ */
+public interface OrderType {
+
+
+    /**
+     * @return the name of the field of the entity that identifies the column in the DB
+     */
+    String getColumnName();
+
+}

--- a/src/main/java/it/gov/pagopa/bizeventsservice/util/Util.java
+++ b/src/main/java/it/gov/pagopa/bizeventsservice/util/Util.java
@@ -50,7 +50,7 @@ public class Util {
         return pages;
     }
     
-	private static void getSortedList(List<BizEventsViewUser> mergedListByTIDOfViewUser, TransactionListOrder order,
+	public static void getSortedList(List<BizEventsViewUser> mergedListByTIDOfViewUser, TransactionListOrder order,
 			Direction direction) {
 		if (TransactionListOrder.TRANSACTION_DATE.equals(order)) {
 			switch (direction) {
@@ -64,6 +64,18 @@ public class Util {
 						Comparator.nullsLast(Comparator.naturalOrder())).reversed());
 				break;
 			}
+		} else if (TransactionListOrder.TAX_CODE.equals(order)){
+			switch (direction) {
+			case ASC:
+				Collections.sort(mergedListByTIDOfViewUser, Comparator.comparing(BizEventsViewUser::getTaxCode,
+						Comparator.nullsLast(Comparator.naturalOrder())));
+				break;
+			case DESC:
+			default:
+				Collections.sort(mergedListByTIDOfViewUser, Comparator.comparing(BizEventsViewUser::getTaxCode,
+						Comparator.nullsLast(Comparator.naturalOrder())).reversed());
+				break;
+			}	
 		} else {
 			// the default sorting is by transaction date and DESC direction
 			Collections.sort(mergedListByTIDOfViewUser, Comparator

--- a/src/test/java/it/gov/pagopa/bizeventsservice/controller/PaymentsControllerTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/controller/PaymentsControllerTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import it.gov.pagopa.bizeventsservice.model.response.CtReceiptModelResponse;
 import it.gov.pagopa.bizeventsservice.service.IBizEventsService;
-import it.gov.pagopa.bizeventsservice.util.UtilityForTest;
+import it.gov.pagopa.bizeventsservice.util.Utility;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -39,7 +39,7 @@ class PaymentsControllerTest {
 	@BeforeEach
     void setUp() throws IOException {
 		// precondition
-		CtReceiptModelResponse ctReceiptModel = UtilityForTest.readModelFromFile("receipts/getOrganizationReceipt.json", CtReceiptModelResponse.class);
+		CtReceiptModelResponse ctReceiptModel = Utility.readModelFromFile("receipts/getOrganizationReceipt.json", CtReceiptModelResponse.class);
         when(bizEventsService.getOrganizationReceipt(anyString(), anyString(), anyString())).thenReturn(ctReceiptModel);
         when(bizEventsService.getOrganizationReceipt(anyString(), anyString())).thenReturn(ctReceiptModel);
     }

--- a/src/test/java/it/gov/pagopa/bizeventsservice/controller/PaymentsControllerTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/controller/PaymentsControllerTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import it.gov.pagopa.bizeventsservice.model.response.CtReceiptModelResponse;
 import it.gov.pagopa.bizeventsservice.service.IBizEventsService;
-import it.gov.pagopa.bizeventsservice.util.TestUtil;
+import it.gov.pagopa.bizeventsservice.util.UtilityForTest;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -39,7 +39,7 @@ class PaymentsControllerTest {
 	@BeforeEach
     void setUp() throws IOException {
 		// precondition
-		CtReceiptModelResponse ctReceiptModel = TestUtil.readModelFromFile("receipts/getOrganizationReceipt.json", CtReceiptModelResponse.class);
+		CtReceiptModelResponse ctReceiptModel = UtilityForTest.readModelFromFile("receipts/getOrganizationReceipt.json", CtReceiptModelResponse.class);
         when(bizEventsService.getOrganizationReceipt(anyString(), anyString(), anyString())).thenReturn(ctReceiptModel);
         when(bizEventsService.getOrganizationReceipt(anyString(), anyString())).thenReturn(ctReceiptModel);
     }

--- a/src/test/java/it/gov/pagopa/bizeventsservice/controller/TransactionControllerTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/controller/TransactionControllerTest.java
@@ -13,7 +13,7 @@ import it.gov.pagopa.bizeventsservice.model.response.transaction.TransactionList
 import it.gov.pagopa.bizeventsservice.model.response.transaction.TransactionListResponse;
 import it.gov.pagopa.bizeventsservice.service.IBizEventsService;
 import it.gov.pagopa.bizeventsservice.service.ITransactionService;
-import it.gov.pagopa.bizeventsservice.util.TestUtil;
+import it.gov.pagopa.bizeventsservice.util.UtilityForTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,9 +78,9 @@ public class TransactionControllerTest {
     @BeforeEach
     void setUp() throws IOException {
         // precondition
-        List<TransactionListItem> transactionListItems = TestUtil.readModelFromFile("biz-events/getTransactionList.json", List.class);
+        List<TransactionListItem> transactionListItems = UtilityForTest.readModelFromFile("biz-events/getTransactionList.json", List.class);
         TransactionListResponse transactionListResponse = TransactionListResponse.builder().transactionList(transactionListItems).build();
-        TransactionDetailResponse transactionDetailResponse = TestUtil.readModelFromFile("biz-events/transactionDetails.json", TransactionDetailResponse.class);
+        TransactionDetailResponse transactionDetailResponse = UtilityForTest.readModelFromFile("biz-events/transactionDetails.json", TransactionDetailResponse.class);
         when(transactionService.getTransactionList(eq(VALID_FISCAL_CODE), anyString(), anyInt())).thenReturn(transactionListResponse);
         when(transactionService.getCachedTransactionList(eq(VALID_FISCAL_CODE), anyInt(), anyInt())).thenReturn(transactionListResponse);
         when(transactionService.getTransactionDetails(anyString(), anyString())).thenReturn(transactionDetailResponse);

--- a/src/test/java/it/gov/pagopa/bizeventsservice/controller/TransactionControllerTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/controller/TransactionControllerTest.java
@@ -13,7 +13,7 @@ import it.gov.pagopa.bizeventsservice.model.response.transaction.TransactionList
 import it.gov.pagopa.bizeventsservice.model.response.transaction.TransactionListResponse;
 import it.gov.pagopa.bizeventsservice.service.IBizEventsService;
 import it.gov.pagopa.bizeventsservice.service.ITransactionService;
-import it.gov.pagopa.bizeventsservice.util.UtilityForTest;
+import it.gov.pagopa.bizeventsservice.util.Utility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -78,9 +78,9 @@ public class TransactionControllerTest {
     @BeforeEach
     void setUp() throws IOException {
         // precondition
-        List<TransactionListItem> transactionListItems = UtilityForTest.readModelFromFile("biz-events/getTransactionList.json", List.class);
+        List<TransactionListItem> transactionListItems = Utility.readModelFromFile("biz-events/getTransactionList.json", List.class);
         TransactionListResponse transactionListResponse = TransactionListResponse.builder().transactionList(transactionListItems).build();
-        TransactionDetailResponse transactionDetailResponse = UtilityForTest.readModelFromFile("biz-events/transactionDetails.json", TransactionDetailResponse.class);
+        TransactionDetailResponse transactionDetailResponse = Utility.readModelFromFile("biz-events/transactionDetails.json", TransactionDetailResponse.class);
         when(transactionService.getTransactionList(eq(VALID_FISCAL_CODE), anyString(), anyInt())).thenReturn(transactionListResponse);
         when(transactionService.getCachedTransactionList(eq(VALID_FISCAL_CODE), anyInt(), anyInt())).thenReturn(transactionListResponse);
         when(transactionService.getTransactionDetails(anyString(), anyString())).thenReturn(transactionDetailResponse);

--- a/src/test/java/it/gov/pagopa/bizeventsservice/service/BizEventsServiceTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/service/BizEventsServiceTest.java
@@ -28,7 +28,7 @@ import it.gov.pagopa.bizeventsservice.exception.AppException;
 import it.gov.pagopa.bizeventsservice.model.response.CtReceiptModelResponse;
 import it.gov.pagopa.bizeventsservice.repository.BizEventsRepository;
 import it.gov.pagopa.bizeventsservice.service.impl.BizEventsService;
-import it.gov.pagopa.bizeventsservice.util.TestUtil;
+import it.gov.pagopa.bizeventsservice.util.UtilityForTest;
 
 @TestMethodOrder(OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -54,8 +54,8 @@ class BizEventsServiceTest {
 
     @BeforeAll
     public void beforeAll() throws IOException {
-        bizEventEntity = TestUtil.readModelFromFile("biz-events/bizEvent.json", BizEvent.class);
-        bizEventEntityDuplicated = TestUtil.readModelFromFile("biz-events/bizEvent_duplicate.json", BizEvent.class);
+        bizEventEntity = UtilityForTest.readModelFromFile("biz-events/bizEvent.json", BizEvent.class);
+        bizEventEntityDuplicated = UtilityForTest.readModelFromFile("biz-events/bizEvent_duplicate.json", BizEvent.class);
     }
 
     @BeforeEach

--- a/src/test/java/it/gov/pagopa/bizeventsservice/service/BizEventsServiceTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/service/BizEventsServiceTest.java
@@ -28,7 +28,7 @@ import it.gov.pagopa.bizeventsservice.exception.AppException;
 import it.gov.pagopa.bizeventsservice.model.response.CtReceiptModelResponse;
 import it.gov.pagopa.bizeventsservice.repository.BizEventsRepository;
 import it.gov.pagopa.bizeventsservice.service.impl.BizEventsService;
-import it.gov.pagopa.bizeventsservice.util.UtilityForTest;
+import it.gov.pagopa.bizeventsservice.util.Utility;
 
 @TestMethodOrder(OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -54,8 +54,8 @@ class BizEventsServiceTest {
 
     @BeforeAll
     public void beforeAll() throws IOException {
-        bizEventEntity = UtilityForTest.readModelFromFile("biz-events/bizEvent.json", BizEvent.class);
-        bizEventEntityDuplicated = UtilityForTest.readModelFromFile("biz-events/bizEvent_duplicate.json", BizEvent.class);
+        bizEventEntity = Utility.readModelFromFile("biz-events/bizEvent.json", BizEvent.class);
+        bizEventEntityDuplicated = Utility.readModelFromFile("biz-events/bizEvent_duplicate.json", BizEvent.class);
     }
 
     @BeforeEach

--- a/src/test/java/it/gov/pagopa/bizeventsservice/service/TransactionServiceTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/service/TransactionServiceTest.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.bizeventsservice.service;
 import com.azure.spring.data.cosmos.core.query.CosmosPageRequest;
 
 import feign.FeignException;
+import io.lettuce.core.GeoArgs.Sort;
 import it.gov.pagopa.bizeventsservice.client.IReceiptGeneratePDFClient;
 import it.gov.pagopa.bizeventsservice.client.IReceiptGetPDFClient;
 import it.gov.pagopa.bizeventsservice.entity.BizEvent;
@@ -378,7 +379,8 @@ public class TransactionServiceTest {
         when(bizEventsViewCartRepository.getBizEventsViewCartByTransactionIdAndFilteredByTaxCode(contains("_nocart"), eq(ViewGenerator.USER_TAX_CODE_WITH_TX)))
         .thenReturn(listOfSingleViewCart);
         // taxcode is in cache
-        byte[] data = SerializationUtils.serialize((Serializable)Util.getPaginatedList(listOfViewUser, PAGE_SIZE));
+        List<BizEventsViewUser> mergedListOfViewUser = new ArrayList<>(Util.getMergedListByTID(listOfViewUser));
+        byte[] data = SerializationUtils.serialize((Serializable)mergedListOfViewUser);
         when(redisRepository.get(anyString())).thenReturn(data);
         
         

--- a/src/test/java/it/gov/pagopa/bizeventsservice/service/TransactionServiceTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/service/TransactionServiceTest.java
@@ -3,7 +3,6 @@ package it.gov.pagopa.bizeventsservice.service;
 import com.azure.spring.data.cosmos.core.query.CosmosPageRequest;
 
 import feign.FeignException;
-import io.lettuce.core.GeoArgs.Sort;
 import it.gov.pagopa.bizeventsservice.client.IReceiptGeneratePDFClient;
 import it.gov.pagopa.bizeventsservice.client.IReceiptGetPDFClient;
 import it.gov.pagopa.bizeventsservice.entity.BizEvent;

--- a/src/test/java/it/gov/pagopa/bizeventsservice/util/UtilTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/util/UtilTest.java
@@ -1,0 +1,33 @@
+package it.gov.pagopa.bizeventsservice.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort.Direction;
+
+import it.gov.pagopa.bizeventsservice.entity.view.BizEventsViewUser;
+import it.gov.pagopa.bizeventsservice.model.filterandorder.Order.TransactionListOrder;
+
+public class UtilTest {
+	
+	@Test
+	void checkListSortingByOrderAndDirection()  {
+		List<BizEventsViewUser> listOfViewUser = ViewGenerator.generateListOf95MixedBizEventsViewUser();
+		List<BizEventsViewUser> mergedListOfViewUser = new ArrayList<>(Util.getMergedListByTID(listOfViewUser));
+		Util.getSortedList(mergedListOfViewUser, TransactionListOrder.TRANSACTION_DATE, Direction.ASC);
+		Assertions.assertEquals("2024-06-07T11:07:46Z", mergedListOfViewUser.get(0).getTransactionDate()); // first element
+		Assertions.assertEquals("2024-06-12T11:07:46Z", mergedListOfViewUser.get(mergedListOfViewUser.size()-1).getTransactionDate()); // last element
+		Util.getSortedList(mergedListOfViewUser, TransactionListOrder.TRANSACTION_DATE, Direction.DESC);
+		Assertions.assertEquals("2024-06-12T11:07:46Z", mergedListOfViewUser.get(0).getTransactionDate()); // first element
+		Assertions.assertEquals("2024-06-07T11:07:46Z", mergedListOfViewUser.get(mergedListOfViewUser.size()-1).getTransactionDate()); // last element
+		Util.getSortedList(mergedListOfViewUser, TransactionListOrder.TAX_CODE, Direction.ASC);
+		Assertions.assertEquals(ViewGenerator.USER_TAX_CODE_WITH_TX, mergedListOfViewUser.get(0).getTaxCode()); // first element
+		Assertions.assertEquals(ViewGenerator.USER_TAX_CODE_WITH_TX, mergedListOfViewUser.get(mergedListOfViewUser.size()-1).getTaxCode()); // last element
+		Util.getSortedList(mergedListOfViewUser, TransactionListOrder.TAX_CODE, Direction.DESC);
+		Assertions.assertEquals(ViewGenerator.USER_TAX_CODE_WITH_TX, mergedListOfViewUser.get(0).getTaxCode()); // first element
+		Assertions.assertEquals(ViewGenerator.USER_TAX_CODE_WITH_TX, mergedListOfViewUser.get(mergedListOfViewUser.size()-1).getTaxCode()); // last element
+    }
+
+}

--- a/src/test/java/it/gov/pagopa/bizeventsservice/util/UtilTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/util/UtilTest.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.Sort.Direction;
 import it.gov.pagopa.bizeventsservice.entity.view.BizEventsViewUser;
 import it.gov.pagopa.bizeventsservice.model.filterandorder.Order.TransactionListOrder;
 
-public class UtilTest {
+class UtilTest {
 	
 	@Test
 	void checkListSortingByOrderAndDirection()  {

--- a/src/test/java/it/gov/pagopa/bizeventsservice/util/Utility.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/util/Utility.java
@@ -12,10 +12,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
-public class UtilityForTest {
+public class Utility {
 
 	public static <T> T readModelFromFile(String relativePath, Class<T> clazz) throws IOException {
-		ClassLoader classLoader = UtilityForTest.class.getClassLoader();
+		ClassLoader classLoader = Utility.class.getClassLoader();
 		File file = new File(Objects.requireNonNull(classLoader.getResource(relativePath)).getPath());
 		var content = Files.readString(file.toPath());
 		ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/it/gov/pagopa/bizeventsservice/util/UtilityForTest.java
+++ b/src/test/java/it/gov/pagopa/bizeventsservice/util/UtilityForTest.java
@@ -12,10 +12,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
-public class TestUtil {
+public class UtilityForTest {
 
 	public static <T> T readModelFromFile(String relativePath, Class<T> clazz) throws IOException {
-		ClassLoader classLoader = TestUtil.class.getClassLoader();
+		ClassLoader classLoader = UtilityForTest.class.getClassLoader();
 		File file = new File(Objects.requireNonNull(classLoader.getResource(relativePath)).getPath());
 		var content = Files.readString(file.toPath());
 		ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- changed the behavior of the API so that the already paginated list is not cached
- added provision for possible custom sorting in the future

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- caching the already paged list does not allow you to change the size of the page in subsequent calls

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- manual and junit test

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.