### PR TITLE
fix: [PQ-116] - get org. receipt date fromat

### DIFF
--- a/src/main/java/it/gov/pagopa/bizeventsservice/model/response/CtReceiptModelResponse.java
+++ b/src/main/java/it/gov/pagopa/bizeventsservice/model/response/CtReceiptModelResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import it.gov.pagopa.bizeventsservice.model.MapEntry;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -66,9 +67,16 @@ public class CtReceiptModelResponse implements Serializable {
     private BigDecimal primaryCiIncurredFee;
     private String idBundle;
     private String idCiBundle;
+
+    @JsonFormat(pattern="yyyy-MM-dd")
     private LocalDate  paymentDateTime;
+
+    @JsonFormat(pattern="yyyy-MM-dd")
     private LocalDate  applicationDate;
+
+    @JsonFormat(pattern="yyyy-MM-dd")
     private LocalDate  transferDate;
+
     private List<MapEntry> metadata;
 
 }

--- a/src/main/java/it/gov/pagopa/bizeventsservice/model/response/Debtor.java
+++ b/src/main/java/it/gov/pagopa/bizeventsservice/model/response/Debtor.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import it.gov.pagopa.bizeventsservice.model.response.enumeration.EntityUniqueIdentifierType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,5 +34,6 @@ public class Debtor implements Serializable{
     private String city;
     private String stateProvinceRegion;
     private String country;
+	@JsonProperty(value="eMail")
     private String eMail;
 }

--- a/src/main/java/it/gov/pagopa/bizeventsservice/model/response/Payer.java
+++ b/src/main/java/it/gov/pagopa/bizeventsservice/model/response/Payer.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import it.gov.pagopa.bizeventsservice.model.response.enumeration.EntityUniqueIdentifierType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,5 +34,6 @@ public class Payer implements Serializable{
 	private String city;
 	private String stateProvinceRegion;
 	private String country;
+	@JsonProperty(value="eMail")
 	private String eMail;
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Fixed `getOrganizationReceipt` output date format for the following fields:

- `applicationDate`
- `paymentDateTime`
- `transferDate`

Fixed `email` field duplicate output
#### Motivation and Context

As reported by [SMO issue](https://pagopa.atlassian.net/browse/PTPO-281), the format of the fields listed above were no compliant with the specifications, date format was array of int instead of formatted string `yyyy-MM-dd`.

As reported by users the email output was duplicated, causing problems with the various mappings

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.